### PR TITLE
enhance connection callback with detailed failure reporting

### DIFF
--- a/feather-quic-core/src/lib.rs
+++ b/feather-quic-core/src/lib.rs
@@ -1,7 +1,7 @@
 // Re-export commonly used types and functions
 pub mod prelude {
     pub use crate::config::{QuicConfig, DEFAULT_INITIAL_PACKET_SIZE};
-    pub use crate::connection::{QuicConnection, QuicConnectionError};
+    pub use crate::connection::{QuicConnectResult, QuicConnection, QuicConnectionError};
     pub use crate::runtime::{QuicCallbacks, QuicRuntime, QuicUserContext, RuntimeConfig};
     pub use crate::stream::{QuicStreamError, QuicStreamHandle};
 }

--- a/feather-quic-integration-tests/src/tests/connect_failure_test.rs
+++ b/feather-quic-integration-tests/src/tests/connect_failure_test.rs
@@ -1,0 +1,149 @@
+#[cfg(test)]
+mod tests {
+    use crate::utils::{init_logging, TestEnvironment};
+    use anyhow::{anyhow, Result};
+    use tracing::{info, warn};
+
+    async fn run_connect_failure_wrong_alpn_test(use_io_uring: bool) -> Result<()> {
+        init_logging();
+        let io_uring_str = if use_io_uring { " with io_uring" } else { "" };
+        info!("Starting idle timeout test{}...", io_uring_str);
+
+        let server_config = vec!["--listen", "127.0.0.1:44433"];
+
+        let mut test_env = TestEnvironment::setup(&server_config).await?;
+
+        let mut client_config = vec![
+            "--target-address",
+            "127.0.0.1:44433",
+            "--sni",
+            "localhost",
+            "--first-initial-packet-size",
+            "1200",
+            "--scid",
+            "aaaa1baa11",
+            "--alpn",
+            "ECHO",
+            "-e",
+            "feather-quic-integration-tests/src/tests/test_files/basic_echo_input",
+            "--idle-timeout",
+            "5000", // 3 seconds
+        ];
+
+        if use_io_uring {
+            client_config.push("--use-io-uring");
+        }
+
+        let success_patterns = [
+            "QUIC connection establishment failed, due to",
+            "peer doesn't support any known protocol",
+        ];
+
+        let failure_patterns = ["QUIC connection established successfully"];
+
+        let test_result = test_env
+            .run_client_test(&client_config, &success_patterns, &failure_patterns, 5)
+            .await;
+
+        if let Err(error) = &test_result {
+            warn!("Test failed. Error: {}", error);
+            test_env.test_failed = true;
+        }
+
+        let cleanup_result = test_env.cleanup().await;
+
+        let final_result = match (test_result, cleanup_result) {
+            (Ok(_), Ok(_)) => Ok(()),
+            (Err(test_err), Ok(_)) => Err(test_err),
+            (Ok(_), Err(cleanup_err)) => Err(cleanup_err),
+            (Err(test_err), Err(cleanup_err)) => Err(anyhow!("{}\n{}", test_err, cleanup_err)),
+        };
+
+        if let Err(e) = &final_result {
+            warn!("Test execution or cleanup failed: {}", e);
+        }
+
+        final_result
+    }
+
+    async fn run_connect_failure_idle_timeout_test(use_io_uring: bool) -> Result<()> {
+        init_logging();
+        let io_uring_str = if use_io_uring { " with io_uring" } else { "" };
+        info!("Starting idle timeout test{}...", io_uring_str);
+
+        let server_config = vec!["--listen", "127.0.0.1:44433"];
+
+        let mut test_env = TestEnvironment::setup(&server_config).await?;
+
+        let mut client_config = vec![
+            "--target-address",
+            "127.0.0.1:44433",
+            "--sni",
+            "localhost",
+            "--first-initial-packet-size",
+            "1200",
+            "--scid",
+            "aaaa1baa11",
+            "--alpn",
+            "echo",
+            "-e",
+            "feather-quic-integration-tests/src/tests/test_files/basic_echo_input",
+            "--idle-timeout",
+            "3000", // 3 seconds
+            "--send-loss-rate",
+            "1.0",
+        ];
+
+        if use_io_uring {
+            client_config.push("--use-io-uring");
+        }
+
+        let success_patterns = ["QUIC connection establishment timed out after 3000ms"];
+
+        let failure_patterns = ["QUIC connection established successfully"];
+
+        let test_result = test_env
+            .run_client_test(&client_config, &success_patterns, &failure_patterns, 5)
+            .await;
+
+        if let Err(error) = &test_result {
+            warn!("Test failed. Error: {}", error);
+            test_env.test_failed = true;
+        }
+
+        let cleanup_result = test_env.cleanup().await;
+
+        let final_result = match (test_result, cleanup_result) {
+            (Ok(_), Ok(_)) => Ok(()),
+            (Err(test_err), Ok(_)) => Err(test_err),
+            (Ok(_), Err(cleanup_err)) => Err(cleanup_err),
+            (Err(test_err), Err(cleanup_err)) => Err(anyhow!("{}\n{}", test_err, cleanup_err)),
+        };
+
+        if let Err(e) = &final_result {
+            warn!("Test execution or cleanup failed: {}", e);
+        }
+
+        final_result
+    }
+
+    #[tokio::test]
+    pub async fn test_connect_failure_idle_timeout() -> Result<()> {
+        run_connect_failure_idle_timeout_test(false).await
+    }
+
+    #[tokio::test]
+    pub async fn test_connect_failure_idle_timeout_io_uring() -> Result<()> {
+        run_connect_failure_idle_timeout_test(true).await
+    }
+
+    #[tokio::test]
+    pub async fn test_connect_failure_wrong_alpn() -> Result<()> {
+        run_connect_failure_wrong_alpn_test(false).await
+    }
+
+    #[tokio::test]
+    pub async fn test_connect_failure_wrong_alpn_io_uring() -> Result<()> {
+        run_connect_failure_wrong_alpn_test(true).await
+    }
+}

--- a/feather-quic-integration-tests/src/tests/mod.rs
+++ b/feather-quic-integration-tests/src/tests/mod.rs
@@ -1,4 +1,5 @@
 pub mod close_connection_test;
+pub mod connect_failure_test;
 pub mod echo_test;
 pub mod finish_stream_test;
 pub mod idle_timeout_test;

--- a/feather-quic-tools/src/client_tool.rs
+++ b/feather-quic-tools/src/client_tool.rs
@@ -54,8 +54,27 @@ impl QuicCallbacks for FeatherQuicClientContext {
         Ok(())
     }
 
-    fn connect_done(&mut self, qconn: &mut QuicConnection) -> Result<()> {
-        info!("QUIC connection established successfully");
+    fn connect_done(
+        &mut self,
+        qconn: &mut QuicConnection,
+        result: QuicConnectResult,
+    ) -> Result<()> {
+        match result {
+            QuicConnectResult::Success => {
+                info!("QUIC connection established successfully");
+            }
+            QuicConnectResult::Timeout(duration) => {
+                info!(
+                    "QUIC connection establishment timed out after {}ms",
+                    duration
+                );
+                return Ok(());
+            }
+            QuicConnectResult::Failed(reason) => {
+                info!("QUIC connection establishment failed, due to {}", reason);
+                return Ok(());
+            }
+        }
 
         let new_stream = qconn.open_stream(true)?;
 

--- a/feather-quic-tools/src/echo_context.rs
+++ b/feather-quic-tools/src/echo_context.rs
@@ -233,8 +233,27 @@ impl QuicCallbacks for FeatherQuicEchoContext {
         Ok(())
     }
 
-    fn connect_done(&mut self, qconn: &mut QuicConnection) -> Result<()> {
-        info!("QUIC connection established successfully");
+    fn connect_done(
+        &mut self,
+        qconn: &mut QuicConnection,
+        result: QuicConnectResult,
+    ) -> Result<()> {
+        match result {
+            QuicConnectResult::Success => {
+                info!("QUIC connection established successfully");
+            }
+            QuicConnectResult::Timeout(duration) => {
+                info!(
+                    "QUIC connection establishment timed out after {}ms",
+                    duration
+                );
+                return Ok(());
+            }
+            QuicConnectResult::Failed(reason) => {
+                info!("QUIC connection establishment failed, due to {}", reason);
+                return Ok(());
+            }
+        }
 
         // Create multiple streams
         for _ in 0..self.num_streams {


### PR DESCRIPTION
Add detailed connection failure reporting through the connect_done callback 
with three possible result types:
- Success: When connection is established successfully
- Timeout: When connection establishment times out with duration
- Failed: When connection fails with detailed error reason

Add tests for connection failure scenarios (wrong ALPN, timeout) to verify
callback behavior in both standard and io_uring runtime environments.