### PR TITLE
add cross-platform timer support for macOS and Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,10 @@ categories = ["network-programming", "protocols"]
 
 [workspace.dependencies]
 mio = { version = "1.0.2", features = ["net", "os-poll"] }
-mio-timerfd = { version = "0.3.0", git = "https://github.com/swananan/mio-timerfd.git"}
 log = "0.4.22"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 rand = "0.8.5"
 anyhow = "1.0.93"
-io-uring = "0.7.2"
 slab = "0.4.9"
 libc = "0.2.169"
 aes = "0.8.4"

--- a/README.en.md
+++ b/README.en.md
@@ -19,7 +19,7 @@ To be continued
 
 **Building and Debugging**
 
-Currently, compilation is only supported on Linux platforms due to the use of Linux timerfd for high-precision timers. Support for Mac and Windows platforms will be added soon.
+Currently, compilation is tested on Linux and MacOS platforms. Windows platform has not been tested yet, but it should be ok.
 
 Build command:
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ feather-quic 是一个个人实验性质项目，使用 Rust 实现 QUIC 协议�
 ---
 **构建和调试**
 
-目前仅支持在 Linux 平台上编译，因为使用了 Linux timerfd 实现高精度定时器。后续将快速支持 Mac 和 Windows 平台。
+目前在 Linux 和 Mac 平台都进行过测试，Windows 平台理论上支持。
 
 构建命令:
 

--- a/feather-quic-core/Cargo.toml
+++ b/feather-quic-core/Cargo.toml
@@ -11,11 +11,9 @@ categories = ["network-programming", "protocols"]
 
 [dependencies]
 mio = { workspace = true }
-mio-timerfd = { workspace = true }
 log = { workspace = true }
 rand = { workspace = true }
 anyhow = { workspace = true }
-io-uring = { workspace = true }
 slab = { workspace = true }
 libc = { workspace = true }
 aes = { workspace = true }
@@ -24,4 +22,8 @@ byteorder = { workspace = true }
 tracing = { workspace = true }
 tracing-log = { workspace = true }
 thiserror = { workspace = true }
-tracing-subscriber = { workspace = true } 
+tracing-subscriber = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+io-uring = "0.7.2"
+mio-timerfd = { version = "0.3.0", git = "https://github.com/swananan/mio-timerfd.git"}

--- a/feather-quic-integration-tests/src/tests/close_connection_test.rs
+++ b/feather-quic-integration-tests/src/tests/close_connection_test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use crate::utils::{init_logging, TestEnvironment};
+    use crate::utils::{init_logging, platform::is_io_uring_supported, TestEnvironment};
     use anyhow::{anyhow, Result};
     use tracing::{info, warn};
 
@@ -77,6 +77,9 @@ mod tests {
 
     #[tokio::test]
     pub async fn test_close_connection_io_uring() -> Result<()> {
+        if !is_io_uring_supported() {
+            return Ok(());
+        }
         run_close_connection_test(true).await
     }
 }

--- a/feather-quic-integration-tests/src/tests/connect_failure_test.rs
+++ b/feather-quic-integration-tests/src/tests/connect_failure_test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use crate::utils::{init_logging, TestEnvironment};
+    use crate::utils::{init_logging, platform::is_io_uring_supported, TestEnvironment};
     use anyhow::{anyhow, Result};
     use tracing::{info, warn};
 
@@ -134,6 +134,9 @@ mod tests {
 
     #[tokio::test]
     pub async fn test_connect_failure_idle_timeout_io_uring() -> Result<()> {
+        if !is_io_uring_supported() {
+            return Ok(());
+        }
         run_connect_failure_idle_timeout_test(true).await
     }
 
@@ -144,6 +147,9 @@ mod tests {
 
     #[tokio::test]
     pub async fn test_connect_failure_wrong_alpn_io_uring() -> Result<()> {
+        if !is_io_uring_supported() {
+            return Ok(());
+        }
         run_connect_failure_wrong_alpn_test(true).await
     }
 }

--- a/feather-quic-integration-tests/src/tests/echo_test.rs
+++ b/feather-quic-integration-tests/src/tests/echo_test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use crate::utils::{init_logging, TestEnvironment};
+    use crate::utils::{init_logging, platform::is_io_uring_supported, TestEnvironment};
     use anyhow::{anyhow, Result};
     use test_log::test;
     use tracing::{info, warn};
@@ -955,12 +955,18 @@ mod tests {
     // Test function that uses io_uring
     #[test(tokio::test)]
     pub async fn test_single_stream_echo_io_uring() -> Result<()> {
+        if !is_io_uring_supported() {
+            return Ok(());
+        }
         run_single_stream_echo_test(true, false).await
     }
 
     // Test function that uses io_uring with key update
     #[test(tokio::test)]
     pub async fn test_single_stream_echo_io_uring_with_key_update() -> Result<()> {
+        if !is_io_uring_supported() {
+            return Ok(());
+        }
         run_single_stream_echo_test(true, true).await
     }
 
@@ -979,12 +985,18 @@ mod tests {
     // Test function that uses io_uring
     #[test(tokio::test)]
     pub async fn test_parallel_stream_echo_io_uring() -> Result<()> {
+        if !is_io_uring_supported() {
+            return Ok(());
+        }
         run_parallel_stream_echo_test(true, false).await
     }
 
     // Test function that uses io_uring with key update
     #[test(tokio::test)]
     pub async fn test_parallel_stream_echo_io_uring_with_key_update() -> Result<()> {
+        if !is_io_uring_supported() {
+            return Ok(());
+        }
         run_parallel_stream_echo_test(true, true).await
     }
 
@@ -1057,71 +1069,107 @@ mod tests {
     // Test function that uses io_uring
     #[test(tokio::test)]
     pub async fn test_large_payload_echo_io_uring() -> Result<()> {
+        if !is_io_uring_supported() {
+            return Ok(());
+        }
         run_large_payload_echo_test(true).await
     }
 
     // Test function that uses io_uring
     #[test(tokio::test)]
     pub async fn test_parallel_large_payload_echo_io_uring() -> Result<()> {
+        if !is_io_uring_supported() {
+            return Ok(());
+        }
         run_parallel_large_payload_echo_test(true).await
     }
 
     // Test function that uses io_uring
     #[test(tokio::test)]
     pub async fn test_long_message_echo_io_uring() -> Result<()> {
+        if !is_io_uring_supported() {
+            return Ok(());
+        }
         run_long_message_echo_test(true).await
     }
 
     // Test function that uses io_uring
     #[test(tokio::test)]
     pub async fn test_parallel_long_message_echo_io_uring() -> Result<()> {
+        if !is_io_uring_supported() {
+            return Ok(());
+        }
         run_parallel_long_message_echo_test(true).await
     }
 
     // Test function that uses io_uring
     #[test(tokio::test)]
     pub async fn test_parallel_long_message_echo_with_packet_loss_io_uring() -> Result<()> {
+        if !is_io_uring_supported() {
+            return Ok(());
+        }
         run_parallel_long_message_echo_with_packet_loss_test(true).await
     }
 
     // Test function that uses io_uring
     #[test(tokio::test)]
     pub async fn test_connection_data_limit_io_uring() -> Result<()> {
+        if !is_io_uring_supported() {
+            return Ok(());
+        }
         run_connection_data_limit_test(true).await
     }
 
     // Test function that uses io_uring
     #[test(tokio::test)]
     pub async fn test_stream_data_limit_io_uring() -> Result<()> {
+        if !is_io_uring_supported() {
+            return Ok(());
+        }
         run_stream_data_limit_test(true).await
     }
 
     // Test function that uses io_uring
     #[test(tokio::test)]
     pub async fn test_connection_data_blocking_io_uring() -> Result<()> {
+        if !is_io_uring_supported() {
+            return Ok(());
+        }
         run_connection_data_blocking_test(true).await
     }
 
     // Test function that uses io_uring
     #[test(tokio::test)]
     pub async fn test_stream_data_blocking_io_uring() -> Result<()> {
+        if !is_io_uring_supported() {
+            return Ok(());
+        }
         run_stream_data_blocking_test(true).await
     }
 
     // Test function that uses io_uring
     #[test(tokio::test)]
     pub async fn test_bidirectional_stream_blocking_io_uring() -> Result<()> {
+        if !is_io_uring_supported() {
+            return Ok(());
+        }
         run_bidirectional_stream_blocking_test(true).await
     }
 
     // Test function that uses io_uring
     #[test(tokio::test)]
     pub async fn test_large_payload_with_packet_loss_io_uring() -> Result<()> {
+        if !is_io_uring_supported() {
+            return Ok(());
+        }
         run_large_payload_with_packet_loss_test(true).await
     }
 
     #[tokio::test]
     async fn test_retry_validation_io_uring() -> Result<()> {
+        if !is_io_uring_supported() {
+            return Ok(());
+        }
         run_retry_validation(true).await
     }
 

--- a/feather-quic-integration-tests/src/tests/finish_stream_test.rs
+++ b/feather-quic-integration-tests/src/tests/finish_stream_test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use crate::utils::{init_logging, TestEnvironment};
+    use crate::utils::{init_logging, platform::is_io_uring_supported, TestEnvironment};
     use anyhow::{anyhow, Result};
     use tracing::{info, warn};
 
@@ -286,6 +286,9 @@ mod tests {
 
     #[tokio::test]
     pub async fn test_normal_finish_stream_io_uring() -> Result<()> {
+        if !is_io_uring_supported() {
+            return Ok(());
+        }
         run_normal_finish_stream_test(true).await
     }
 
@@ -296,6 +299,9 @@ mod tests {
 
     #[tokio::test]
     pub async fn test_finish_stream_with_loss_io_uring() -> Result<()> {
+        if !is_io_uring_supported() {
+            return Ok(());
+        }
         run_finish_stream_with_loss_test(true).await
     }
 
@@ -317,6 +323,9 @@ mod tests {
 
     #[tokio::test]
     pub async fn test_finish_stream_with_selective_loss_io_uring() -> Result<()> {
+        if !is_io_uring_supported() {
+            return Ok(());
+        }
         run_finish_stream_with_selective_loss_test(true).await
     }
 }

--- a/feather-quic-integration-tests/src/tests/idle_timeout_test.rs
+++ b/feather-quic-integration-tests/src/tests/idle_timeout_test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use crate::utils::{init_logging, TestEnvironment};
+    use crate::utils::{init_logging, platform::is_io_uring_supported, TestEnvironment};
     use anyhow::{anyhow, Result};
     use tracing::{info, warn};
 
@@ -74,6 +74,9 @@ mod tests {
 
     #[tokio::test]
     pub async fn test_idle_timeout_io_uring() -> Result<()> {
+        if !is_io_uring_supported() {
+            return Ok(());
+        }
         run_idle_timeout_test(true).await
     }
 }

--- a/feather-quic-integration-tests/src/tests/reset_stream_test.rs
+++ b/feather-quic-integration-tests/src/tests/reset_stream_test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use crate::utils::{init_logging, TestEnvironment};
+    use crate::utils::{init_logging, platform::is_io_uring_supported, TestEnvironment};
     use anyhow::{anyhow, Result};
     use tracing::{info, warn};
 
@@ -77,6 +77,9 @@ mod tests {
 
     #[tokio::test]
     pub async fn test_reset_stream_io_uring() -> Result<()> {
+        if !is_io_uring_supported() {
+            return Ok(());
+        }
         run_reset_stream_test(true).await
     }
 }

--- a/feather-quic-integration-tests/src/utils/mod.rs
+++ b/feather-quic-integration-tests/src/utils/mod.rs
@@ -13,6 +13,8 @@ use tracing_subscriber::fmt::format::Writer;
 use tracing_subscriber::fmt::time::FormatTime;
 use tracing_subscriber::FmtSubscriber;
 
+pub mod platform;
+
 static INIT: Once = Once::new();
 static INIT_SUCCESS: AtomicBool = AtomicBool::new(false);
 static BUILD_ONCE: Once = Once::new();

--- a/feather-quic-integration-tests/src/utils/platform.rs
+++ b/feather-quic-integration-tests/src/utils/platform.rs
@@ -1,0 +1,9 @@
+#[cfg(target_os = "linux")]
+pub fn is_io_uring_supported() -> bool {
+    true
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn is_io_uring_supported() -> bool {
+    false
+}

--- a/feather-quic-tools/src/client_tool.rs
+++ b/feather-quic-tools/src/client_tool.rs
@@ -187,7 +187,7 @@ fn main() -> Result<()> {
         .arg(
             Arg::new("use_io_uring")
                 .long("use-io-uring")
-                .help("Use io-uring-based QUIC runtime instead of default Mio Epoll")
+                .help("Use io-uring-based QUIC runtime instead of default Mio Epoll (Linux only)")
                 .action(clap::ArgAction::SetTrue),
         )
         .arg(
@@ -415,6 +415,12 @@ fn main() -> Result<()> {
     }
 
     let use_io_uring = matches.get_flag("use_io_uring");
+    #[cfg(not(target_os = "linux"))]
+    if use_io_uring {
+        return Err(anyhow::anyhow!(
+            "io_uring is only supported on Linux platforms"
+        ));
+    }
     let target_address = matches.get_one::<String>("target_address").unwrap().clone();
 
     let target_addr: SocketAddr = target_address


### PR DESCRIPTION
On macOS and Windows, I used the poll timeout parameter from Mio to implement a simple timer, since I don't plan to spend much effort building a real cross-platform network library—especially given that MIO doesn't provide a built-in timer.